### PR TITLE
translate to wiki flavor markdown

### DIFF
--- a/fedwiki/.gitignore
+++ b/fedwiki/.gitignore
@@ -1,1 +1,2 @@
 pages
+status

--- a/fedwiki/README.md
+++ b/fedwiki/README.md
@@ -7,8 +7,17 @@ We hope that the best contributions there find there way back here to github.
 [pie.fed.wiki](http://pie.fed.wiki)
 
 # Operation
+Install wiki for local preview.
+```
+npm install -g wiki
+```
+Transform and preview result at localhost:3010
 ```
 ruby transform.rb
+sh preview.sh
+```
+Publish with sufficent ssh credentials.
+```
 sh publish.sh
 ```
 

--- a/fedwiki/preview.sh
+++ b/fedwiki/preview.sh
@@ -1,0 +1,3 @@
+# launch localhost:3010 server to preview site
+# usage: sh preview.sh
+wiki -p 3010 -d . --security_legacy

--- a/fedwiki/publish.sh
+++ b/fedwiki/publish.sh
@@ -2,8 +2,5 @@
 # usage: sh publish.sh
 
 ssh asia 'rm .wiki/pie.fed.wiki/pages/*'
-
 scp pages/* asia:.wiki/pie.fed.wiki/pages
-scp welcome/* asia:.wiki/pie.fed.wiki/pages
-
 ssh asia 'rm .wiki/pie.fed.wiki/status/sitemap.*'


### PR DESCRIPTION
We begin reconciling various markup features while tracking upstream changes. We are now creating TOC entries for # and ## sections. This TOC includes links to github view of original for comparison. Browse recent translation at [pie.fed.wiki](http://pie.fed.wiki)

![image](https://cloud.githubusercontent.com/assets/12127/24709164/e01f2010-19cd-11e7-8da8-7b5644cb64f1.png)
